### PR TITLE
Feature/1.18.x dont check afk players for sleeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
-## 1.18.2 - 1.0.1
-- Fix startup error
+## 1.18.2 - 1.1.0
+- Skip AFK players when vanilla sleeping percentage is checked.
+- Add `simpleafk.bypass_sleep` permission node to allow players to bypass the sleep percentage check without being AFK.
+- Overwrote vanilla's `setIdleTimeout` command, to prevent it from kicking for idle.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ It provides the ability to configure:
 - when (if at all) a player is kicked for being afk too long.
 - Formatting options to format the afk message, kick message and afk name in tab list.
 
+It skips players that are AFK when checking for the percentage of players sleeping.
+
+_This overrides the vanilla `setIdleTimeout` command, and discards any values set in there._
+
 ![AFK Messages](https://github.com/MagnusHJensen/SimpleAFK/blob/1.20.x/images/afk-messages.png?raw=true "Chat messages of a player going AFK and then no longer being marked as AFK")
 
 <details>
 <summary><b>Permission Nodes</b></summary>
 
 Simple AFK introduces some standard permission nodes if you are using a permission system.
+
+_**NOTE:** The default defined in () only matters if you are **NOT** using a permission mod._
 - `simpleafk.toggle` - Allows the player to toggle their AFK status (Default: Everyone has this permission)
 - `simpleafk.toggle.target` - Allows the player to toggle another player's AFK status (Default: Only OP's have this permission)
 - `simpleafk.bypass` - Allows the player to bypass AFK status (Meaning they won't get marked as AFK and won't get kicked) (Default: Only OP's have this permission)
+- `simpleafk.bypass_sleep` - Allows the player to bypass the [sleep required percentage](https://minecraft.fandom.com/wiki/Game_rule) check (Default: Only OP's have this permission)
 
 </details>

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,16 @@ buildscript {
         // These repositories are only for Gradle plugins, put any other repositories in the repository block further below
         maven { url = 'https://maven.minecraftforge.net' }
         maven { url = 'https://maven.parchmentmc.org' }
+        maven {
+            name = 'Sponge Snapshots'
+            url = 'https://repo.spongepowered.org/repository/maven-public/'
+        }
         mavenCentral()
     }
     dependencies {
         classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
         classpath 'org.parchmentmc:librarian:1.+'
+        classpath 'org.spongepowered:mixingradle:0.7-SNAPSHOT'
     }
 }
 // Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
@@ -17,6 +22,7 @@ plugins {
 }
 apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.parchmentmc.librarian.forgegradle'
+apply plugin: 'org.spongepowered.mixin'
 
 
 version = mod_version
@@ -65,6 +71,8 @@ minecraft {
 
             // Comma-separated list of namespaces to load gametests from. Empty = all namespaces.
             property 'forge.enabledGameTestNamespaces', mod_id
+
+            args "--username", "Player"
 
             mods {
                 examplemod {
@@ -167,6 +175,15 @@ dependencies {
     // For more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
+
+    // Apply Mixin AP
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
+}
+
+mixin {
+    // MixinGradle Settings
+    add sourceSets.main, 'mixins.simpleafk.refmap.json'
+    config 'mixins.simpleafk.json'
 }
 
 // Example for how to get properties into the manifest for reading at runtime.

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ mod_name=Simple AFK
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=LGPL-3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.1
+mod_version=1.1.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/dk/magnusjensen/simpleafk/AFKManager.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/AFKManager.java
@@ -9,7 +9,10 @@
 
 package dk.magnusjensen.simpleafk;
 
+import dk.magnusjensen.simpleafk.utils.Permissions;
+import dk.magnusjensen.simpleafk.utils.Utilities;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.server.permission.PermissionAPI;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,6 +38,16 @@ public class AFKManager {
 
     public void removePlayer(UUID player) {
         players.remove(player);
+    }
+
+    public int getAFKCount() {
+        int count = 0;
+        for (AFKPlayer player : players.values()) {
+            if (player.isAfk() || Utilities.hasPermission(player.getPlayer(), Permissions.BYPASS_SLEEP)) {
+                count++;
+            }
+        }
+        return count;
     }
 
 

--- a/src/main/java/dk/magnusjensen/simpleafk/AFKManager.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/AFKManager.java
@@ -9,10 +9,7 @@
 
 package dk.magnusjensen.simpleafk;
 
-import dk.magnusjensen.simpleafk.utils.Permissions;
-import dk.magnusjensen.simpleafk.utils.Utilities;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraftforge.server.permission.PermissionAPI;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,13 +38,11 @@ public class AFKManager {
     }
 
     public int getAFKCount() {
-        int count = 0;
-        for (AFKPlayer player : players.values()) {
-            if (player.isAfk() || Utilities.hasPermission(player.getPlayer(), Permissions.BYPASS_SLEEP)) {
-                count++;
-            }
-        }
-        return count;
+        return (int) players.values().stream().filter(AFKPlayer::isAfk).count();
+    }
+
+    public int getSleepBypassCount() {
+        return (int) players.values().stream().filter(AFKPlayer::bypassSleep).count();
     }
 
 

--- a/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
@@ -118,6 +118,10 @@ public class AFKPlayer {
         return isAfk;
     }
 
+    public boolean bypassSleep() {
+        return Utilities.hasPermission(player, Permissions.BYPASS_SLEEP) || isAfk();
+    }
+
     public BlockPos getLastPosition() {
         return lastPosition;
     }

--- a/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
@@ -39,7 +39,7 @@ public class AFKPlayer {
      * @param player
      */
     public void tick(ServerPlayer player) {
-        if (Utilities.hasPermission(player, Permissions.BYPASS_AFK)) return; // SKip if the player has the bypass permission.
+        if (Utilities.hasPermission(player, Permissions.BYPASS_AFK) || player.isSleeping()) return;
 
         if (hasPlayerMoved(player.blockPosition())) {
             if (isAfk) {
@@ -91,7 +91,7 @@ public class AFKPlayer {
     }
 
     private boolean hasPlayerMoved(BlockPos currentPos) {
-        return !currentPos.equals(lastPosition);
+        return !currentPos.equals(getLastPosition());
     }
 
     private void move(BlockPos pos) {

--- a/src/main/java/dk/magnusjensen/simpleafk/mixin/MinecraftServerMixin.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/mixin/MinecraftServerMixin.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023  legenden
+ * https://github.com/MagnusHJensen/simpleafk
+ *
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ */
+
+package dk.magnusjensen.simpleafk.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+
+    @Inject(method = "getPlayerIdleTimeout", at = @At("HEAD"), cancellable = true)
+    private void onGetPlayerIdleTimeout(CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(0);
+    }
+}

--- a/src/main/java/dk/magnusjensen/simpleafk/mixin/SleepStatusMixin.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/mixin/SleepStatusMixin.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023  legenden
+ * https://github.com/MagnusHJensen/simpleafk
+ *
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ */
+
+package dk.magnusjensen.simpleafk.mixin;
+
+import dk.magnusjensen.simpleafk.AFKManager;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.players.SleepStatus;
+import net.minecraft.util.Mth;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+
+@Mixin(SleepStatus.class)
+public class SleepStatusMixin {
+
+    @Shadow private int activePlayers;
+
+    @Inject(method = "sleepersNeeded", at = @At("HEAD"), cancellable = true)
+    private void onSleepersNeeded(int requiredSleepPercentage, CallbackInfoReturnable<Integer> cir) {
+        int actualActivePlayers = this.activePlayers - AFKManager.getInstance().getAFKCount();
+        cir.setReturnValue(Math.max(1, Mth.ceil((float)(actualActivePlayers * requiredSleepPercentage) / 100.0F)));
+    }
+}

--- a/src/main/java/dk/magnusjensen/simpleafk/mixin/SleepStatusMixin.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/mixin/SleepStatusMixin.java
@@ -10,7 +10,6 @@
 package dk.magnusjensen.simpleafk.mixin;
 
 import dk.magnusjensen.simpleafk.AFKManager;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.players.SleepStatus;
 import net.minecraft.util.Mth;
 import org.spongepowered.asm.mixin.Mixin;
@@ -19,8 +18,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.List;
-
 @Mixin(SleepStatus.class)
 public class SleepStatusMixin {
 
@@ -28,7 +25,7 @@ public class SleepStatusMixin {
 
     @Inject(method = "sleepersNeeded", at = @At("HEAD"), cancellable = true)
     private void onSleepersNeeded(int requiredSleepPercentage, CallbackInfoReturnable<Integer> cir) {
-        int actualActivePlayers = this.activePlayers - AFKManager.getInstance().getAFKCount();
+        int actualActivePlayers = this.activePlayers - AFKManager.getInstance().getSleepBypassCount();
         cir.setReturnValue(Math.max(1, Mth.ceil((float)(actualActivePlayers * requiredSleepPercentage) / 100.0F)));
     }
 }

--- a/src/main/java/dk/magnusjensen/simpleafk/utils/Permissions.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/utils/Permissions.java
@@ -23,6 +23,7 @@ public class Permissions {
     public static final PermissionNode<Boolean> TOGGLE = new PermissionNode<>(SimpleAFK.MOD_ID, "toggle", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> true);
     public static final PermissionNode<Boolean> TOGGLE_OTHER = new PermissionNode<>(SimpleAFK.MOD_ID, "toggle.target", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> isOp(player));
     public static final PermissionNode<Boolean> BYPASS_AFK = new PermissionNode<>(SimpleAFK.MOD_ID, "bypass", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> isOp(player));
+    public static final PermissionNode<Boolean> BYPASS_SLEEP = new PermissionNode<>(SimpleAFK.MOD_ID, "bypass_sleep", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> isOp(player));
 
 
     private static boolean isOp(ServerPlayer player) {
@@ -31,6 +32,6 @@ public class Permissions {
 
     @SubscribeEvent
     public static void onPermissionGather(PermissionGatherEvent.Nodes event) {
-        event.addNodes(TOGGLE, TOGGLE_OTHER, BYPASS_AFK);
+        event.addNodes(TOGGLE, TOGGLE_OTHER, BYPASS_AFK, BYPASS_SLEEP);
     }
 }

--- a/src/main/resources/mixins.simpleafk.json
+++ b/src/main/resources/mixins.simpleafk.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "dk.magnusjensen.simpleafk.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "refmap": "${refmap_target}refmap.json",
+  "server": [
+    "SleepStatusMixin",
+    "MinecraftServerMixin"
+  ],
+  "minVersion": "0.8",
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces new behaviour for bypassing vanilla sleep percentage, but also does not count AFK players towards the total count required.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Closes: #1 for 1.18
