### PR TITLE
Feature/1.20.x add functionality around sleeping percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
-## 1.20.1 - 1.0.0
-- Introduces timed AFK marking
-- Ability to kick player after x seconds of being AFK
-- Ability to format AFK message and kick message to your liking
-- Lists the player name as [AFK] (with ability to customize) in tab list
+## 1.20.1 - 1.1.0
+- Skip AFK players when vanilla sleeping percentage is checked.
+- Add `simpleafk.bypass_sleep` permission node to allow players to bypass the sleep percentage check without being AFK.
+- Overwrote vanilla's `setIdleTimeout` command, to prevent it from kicking for idle.

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ It provides the ability to configure:
 - when (if at all) a player is kicked for being afk too long.
 - Formatting options to format the afk message, kick message and afk name in tab list.
 
+It skips players that are AFK when checking for the percentage of players sleeping.
+
+_This overrides the vanilla `setIdleTimeout` command, and discards any values set in there._
+
 ![AFK Messages](https://github.com/MagnusHJensen/SimpleAFK/blob/1.20.x/images/afk-messages.png?raw=true "Chat messages of a player going AFK and then no longer being marked as AFK")
 
 <details>
 <summary><b>Permission Nodes</b></summary>
 
 Simple AFK introduces some standard permission nodes if you are using a permission system.
+
+_**NOTE:** The default defined in () only matters if you are **NOT** using a permission mod._
 - `simpleafk.toggle` - Allows the player to toggle their AFK status
 - `simpleafk.toggle.target` - Allows the player to toggle another player's AFK status
 - `simpleafk.bypass` - Allows the player to bypass AFK status (Meaning they won't get marked as AFK and won't get kicked)
+- `simpleafk.bypass_sleep` - Allows the player to bypass the [sleep required percentage](https://minecraft.fandom.com/wiki/Game_rule) check (Default: Only OP's have this permission)
 
 </details>

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,16 @@ dependencies {
     // For more info:
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
+    annotationProcessor 'org.spongepowered:mixin:0.8.5:processor'
 }
+
+mixin {
+    // MixinGradle Settings
+    add sourceSets.main, 'mixins.simpleafk.refmap.json'
+    config 'mixins.simpleafk.json'
+}
+
+
 
 // This block of code expands all declared replace properties in the specified resource targets.
 // A missing property will result in an error. Properties are expanded using ${} Groovy notation.

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Simple AFK
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=LGPL-3.0
 # The mod version. See https://semver.org/
-mod_version=1.0.0
+mod_version=1.1.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/dk/magnusjensen/simpleafk/AFKManager.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/AFKManager.java
@@ -37,6 +37,13 @@ public class AFKManager {
         players.remove(player);
     }
 
+    public int getAFKCount() {
+        return (int) players.values().stream().filter(AFKPlayer::isAfk).count();
+    }
+
+    public int getSleepBypassCount() {
+        return (int) players.values().stream().filter(AFKPlayer::bypassesSleep).count();
+    }
 
     public static AFKManager getInstance() {
         if (INSTANCE == null) {

--- a/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
@@ -40,7 +40,7 @@ public class AFKPlayer {
      * @param player
      */
     public void tick(ServerPlayer player) {
-        if (Utilities.hasPermission(player, Permissions.BYPASS_AFK)) return; // SKip if the player has the bypass permission.
+        if (Utilities.hasPermission(player, Permissions.BYPASS_AFK) || player.isSleeping()) return; // SKip if the player has the bypass permission.
 
         if (hasPlayerMoved(player.blockPosition())) {
             if (isAfk) {
@@ -92,7 +92,7 @@ public class AFKPlayer {
     }
 
     private boolean hasPlayerMoved(BlockPos currentPos) {
-        return !currentPos.equals(lastPosition);
+        return !currentPos.equals(getLastPosition());
     }
 
     private void move(BlockPos pos) {
@@ -117,6 +117,10 @@ public class AFKPlayer {
 
     public boolean isAfk() {
         return isAfk;
+    }
+
+    public boolean bypassesSleep() {
+        return isAfk() || Utilities.hasPermission(player, Permissions.BYPASS_SLEEP);
     }
 
     public BlockPos getLastPosition() {

--- a/src/main/java/dk/magnusjensen/simpleafk/mixin/MinecraftServerMixin.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/mixin/MinecraftServerMixin.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2023  legenden
+ * https://github.com/MagnusHJensen/simpleafk
+ *
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ */
+
+package dk.magnusjensen.simpleafk.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+
+    @Inject(method = "getPlayerIdleTimeout", at = @At("HEAD"), cancellable = true)
+    private void onGetPlayerIdleTimeout(CallbackInfoReturnable<Integer> cir) {
+        cir.setReturnValue(0);
+    }
+}

--- a/src/main/java/dk/magnusjensen/simpleafk/mixin/SleepStatusMixin.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/mixin/SleepStatusMixin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023  legenden
+ * https://github.com/MagnusHJensen/simpleafk
+ *
+ *  This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ */
+
+package dk.magnusjensen.simpleafk.mixin;
+
+import dk.magnusjensen.simpleafk.AFKManager;
+import net.minecraft.server.players.SleepStatus;
+import net.minecraft.util.Mth;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(SleepStatus.class)
+public class SleepStatusMixin {
+
+    @Shadow
+    private int activePlayers;
+
+    @Inject(method = "sleepersNeeded", at = @At("HEAD"), cancellable = true)
+    private void onSleepersNeeded(int requiredSleepPercentage, CallbackInfoReturnable<Integer> cir) {
+        int actualActivePlayers = this.activePlayers - AFKManager.getInstance().getSleepBypassCount();
+        cir.setReturnValue(Math.max(1, Mth.ceil((float)(actualActivePlayers * requiredSleepPercentage) / 100.0F)));
+    }
+}

--- a/src/main/java/dk/magnusjensen/simpleafk/utils/Permissions.java
+++ b/src/main/java/dk/magnusjensen/simpleafk/utils/Permissions.java
@@ -23,6 +23,7 @@ public class Permissions {
     public static final PermissionNode<Boolean> TOGGLE = new PermissionNode<>(SimpleAFK.MODID, "toggle", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> true);
     public static final PermissionNode<Boolean> TOGGLE_OTHER = new PermissionNode<>(SimpleAFK.MODID, "toggle.target", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> isOp(player));
     public static final PermissionNode<Boolean> BYPASS_AFK = new PermissionNode<>(SimpleAFK.MODID, "bypass", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> isOp(player));
+    public static final PermissionNode<Boolean> BYPASS_SLEEP = new PermissionNode<>(SimpleAFK.MODID, "bypass_sleep", PermissionTypes.BOOLEAN, (player, playerUUID, context) -> isOp(player));
 
 
     private static boolean isOp(ServerPlayer player) {
@@ -31,6 +32,6 @@ public class Permissions {
 
     @SubscribeEvent
     public static void onPermissionGather(PermissionGatherEvent.Nodes event) {
-        event.addNodes(TOGGLE, TOGGLE_OTHER, BYPASS_AFK);
+        event.addNodes(TOGGLE, TOGGLE_OTHER, BYPASS_AFK, BYPASS_SLEEP);
     }
 }

--- a/src/main/resources/mixins.simpleafk.json
+++ b/src/main/resources/mixins.simpleafk.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "dk.magnusjensen.simpleafk.mixin",
+  "compatibilityLevel": "JAVA_17",
+  "refmap": "${refmap_target}refmap.json",
+  "server": [
+    "SleepStatusMixin",
+    "MinecraftServerMixin"
+  ],
+  "minVersion": "0.8",
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Introduces new behaviour for bypassing vanilla sleep percentage, but also does not count AFK players towards the total count required.

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Closes: #1 for 1.20.1
