### PR TITLE
Refactor AFK logic to fix AFK status bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-# 1.5.1 - 1.21.1
-- Fixed a tick crashing issue
+# 1.5.2 - 1.21.1
+- Fixed an AFK calculation issue, not accounting correctly for both head and move AFK times.

--- a/common/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
+++ b/common/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
@@ -53,24 +53,45 @@ public class AFKPlayer {
         move(player);
         lookAround(player);
 
-
         if (player.level().getGameTime() % 20 == 0) {
             long timestampInSeconds = System.currentTimeMillis() / 1000;
-            // Check if the player is not marked as AFK, and if the player has not moved for the amount of seconds specified in the config.
-            boolean isMoveAfkFactor = timestampInSeconds - timestampSinceLastMove >= ServerConfig.secondsBeforeAfk;
-            boolean isLookAfkFactor = timestampInSeconds - timestampSinceLastLook >= ServerConfig.secondsBeforeAfk;
-            if (!isAfk && (isMoveAfkFactor || isLookAfkFactor)) {
+            if (checkIfShouldBeAfk(timestampInSeconds)) {
                 setAfkStatus();
-            } else if (
-                ServerConfig.secondsBeforeKick > 0 &&
-                    isAfk &&
-                    (timestampInSeconds - timestampSinceAfk >= ServerConfig.secondsBeforeKick ||
-                        timestampInSeconds - timestampSinceLastMove >= ServerConfig.secondsBeforeKick)
-            ) {
-                player.connection.disconnect(Component.literal(ServerConfig.afkKickMessage));
+            } else if (checkIfShouldBeKicked(timestampInSeconds)) {
+                kickPlayer();
             }
         }
+    }
 
+    /**
+     * Check if the player should be AFK, based on movement and current AFK status.
+     * 
+     * @param timestampInSeconds Current timestamp in seconds
+     * @return True if the player should be AFK, false otherwise
+     */
+    public boolean checkIfShouldBeAfk(long timestampInSeconds) {
+        // Check if the player is not marked as AFK, and if the player has not moved for the amount of seconds specified in the config.
+        boolean isMoveAfkFactor = timestampInSeconds - timestampSinceLastMove >= ServerConfig.secondsBeforeAfk;
+        boolean isLookAfkFactor = timestampInSeconds - timestampSinceLastLook >= ServerConfig.secondsBeforeAfk;
+
+        boolean afkFactors = isMoveAfkFactor || isLookAfkFactor;
+
+        return !isAfk && afkFactors;
+    }
+
+    /**
+     * Check if the player should be kicked, based on movement and current AFK status.
+     * 
+     * @param timestampInSeconds Current timestamp in seconds
+     * @return True if the player should be kicked, false otherwise
+     */
+    public boolean checkIfShouldBeKicked(long timestampInSeconds) {
+        boolean isMoveKickFactor = timestampInSeconds - timestampSinceLastMove >= ServerConfig.secondsBeforeKick;
+        boolean isAfkKickFactor = timestampInSeconds - timestampSinceAfk >= ServerConfig.secondsBeforeKick;
+
+        boolean kickFactors = isMoveKickFactor || isAfkKickFactor;
+
+        return ServerConfig.secondsBeforeKick > 0 && isAfk && kickFactors;
     }
 
     public void toggleAfkStatus() {
@@ -84,6 +105,7 @@ public class AFKPlayer {
     private void setAfkStatus() {
         this.isAfk = true;
         this.timestampSinceAfk = System.currentTimeMillis() / 1000;
+        lookAround(player);
         move(player);
         Services.PLATFORM.refreshTabListName(this.player);
 
@@ -99,7 +121,8 @@ public class AFKPlayer {
 
         this.isAfk = false;
         this.timestampSinceAfk = System.currentTimeMillis() / 1000;
-        this.timestampSinceLastMove = System.currentTimeMillis() / 1000;
+        resetMovement();
+        lookAround(player);
         move(player);
         Services.PLATFORM.refreshTabListName(this.player);
 
@@ -108,6 +131,16 @@ public class AFKPlayer {
         } else {
             player.sendSystemMessage(Utilities.formatMessageWithPlayerName(ServerConfig.isNoLongerAfkMessage, player.getDisplayName().getString()), false);
         }
+    }
+
+    public void resetMovement() {
+        long currentTimestamp = System.currentTimeMillis() / 1000;
+        this.timestampSinceLastMove = currentTimestamp;
+        this.timestampSinceLastLook = currentTimestamp;
+    }
+
+    public void kickPlayer() {
+        player.connection.disconnect(Component.literal(ServerConfig.afkKickMessage));
     }
 
     private boolean hasPlayerMoved(ServerPlayer player) {

--- a/common/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
+++ b/common/src/main/java/dk/magnusjensen/simpleafk/AFKPlayer.java
@@ -74,7 +74,7 @@ public class AFKPlayer {
         boolean isMoveAfkFactor = timestampInSeconds - timestampSinceLastMove >= ServerConfig.secondsBeforeAfk;
         boolean isLookAfkFactor = timestampInSeconds - timestampSinceLastLook >= ServerConfig.secondsBeforeAfk;
 
-        boolean afkFactors = isMoveAfkFactor || isLookAfkFactor;
+        boolean afkFactors = isMoveAfkFactor && isLookAfkFactor;
 
         return !isAfk && afkFactors;
     }
@@ -86,12 +86,9 @@ public class AFKPlayer {
      * @return True if the player should be kicked, false otherwise
      */
     public boolean checkIfShouldBeKicked(long timestampInSeconds) {
-        boolean isMoveKickFactor = timestampInSeconds - timestampSinceLastMove >= ServerConfig.secondsBeforeKick;
         boolean isAfkKickFactor = timestampInSeconds - timestampSinceAfk >= ServerConfig.secondsBeforeKick;
 
-        boolean kickFactors = isMoveKickFactor || isAfkKickFactor;
-
-        return ServerConfig.secondsBeforeKick > 0 && isAfk && kickFactors;
+        return ServerConfig.secondsBeforeKick > 0 && isAfk && isAfkKickFactor;
     }
 
     public void toggleAfkStatus() {
@@ -167,17 +164,6 @@ public class AFKPlayer {
 
     public ServerPlayer getPlayer() {
         return player;
-    }
-
-    /**
-     * This does not mean that the player is AFK, to ensure the player is AFK check the isAfk.
-     */
-    public long getSecondsSinceAfk() {
-        return (System.currentTimeMillis() / 1000) - timestampSinceAfk;
-    }
-
-    public long getSecondsSinceLastMove() {
-        return (System.currentTimeMillis() / 1000) - timestampSinceLastMove;
     }
 
     public boolean isAfk() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # Every field you add must be added to buildSrc/src/main/groovy/multiloader-common.gradle expandProps map.
 
 # Project
-version=1.5.1
+version=1.5.2
 group=dk.magnusjensen.simpleafk
 java_version=21
 


### PR DESCRIPTION
Fixed a bug with AFK calculations, where removal of AFK only affected movement timestamp and not head angle timestamp.

This caused the check for AFK (which takes into account the movement timestamp **OR** the head angle timestamp) to retrigger imediatly after chat messages or just movements..

Additionally, I cleaned up some of the logic, so it is easier to maintain.

Tested in 1.21.1 with NeoForge.